### PR TITLE
Update Demia Publisher

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -36,6 +36,9 @@ pub enum Error {
     #[error("Mqtt Connect Return error: {0}")]
     MqttConnectReturnError(String),
 
+    #[error("No Identity present in the user")]
+    StreamsNoIdentity,
+
     #[error("Did not find keyload, subscription may not have been processed correctly")]
     StreamsKeyloadNotFound,
 

--- a/src/providers/stream_provider/demia.rs
+++ b/src/providers/stream_provider/demia.rs
@@ -56,7 +56,7 @@ impl DemiaPublisher {
                     user,
                     identifier,
                 })
-            },
+            }
             None => Err(Error::StreamsNoIdentity),
         }
     }
@@ -293,18 +293,19 @@ mod demia_test {
         info!("Publishing...");
         publisher.publish(data).await.unwrap();
 
-
         let user = User::restore(
             std::fs::read("temp_file").unwrap(),
-            "password", Client::new("http://localhost:8080")
-        ).await.unwrap();
+            "password",
+            Client::new("http://localhost:8080"),
+        )
+        .await
+        .unwrap();
 
         let restored = DemiaPublisher::new_with_user(&sdk_info.stream, user).unwrap();
 
         assert!(restored.identifier.eq(publisher.identifier()));
         std::fs::remove_file("temp_file").unwrap();
     }
-
 
     async fn mock_provider(sdk_info: SdkInfo) -> DemiaPublisher {
         if let StreamConfig::DemiaStreams(config) = &sdk_info.stream.config {

--- a/src/providers/stream_provider/mqtt.rs
+++ b/src/providers/stream_provider/mqtt.rs
@@ -1,9 +1,9 @@
-use std::sync::Arc;
 use crate::config::{MqttStreamConfig, StreamConfig, StreamInfo};
 use crate::errors::{Error, Result};
 use alvarium_annotator::{MessageWrapper, Publisher};
 use log::{debug, warn};
 use rumqttc::{AsyncClient, ConnectionError, EventLoop, MqttOptions, QoS};
+use std::sync::Arc;
 use tokio::sync::Mutex;
 
 pub struct MqttPublisher {

--- a/src/sdk.rs
+++ b/src/sdk.rs
@@ -14,7 +14,9 @@ pub struct SDK<'a, Pub: Publisher> {
     stream: Pub,
 }
 
-impl<'a, Pub: Publisher<StreamConfig = StreamInfo, Error = crate::errors::Error> + Send + Sync> SDK<'a, Pub> {
+impl<'a, Pub: Publisher<StreamConfig = StreamInfo, Error = crate::errors::Error> + Send + Sync>
+    SDK<'a, Pub>
+{
     pub async fn new(
         cfg: SdkInfo,
         annotators: &'a mut [Box<SdkAnnotator>],


### PR DESCRIPTION
Allow for the `Demia Publisher` to inject an existing user instance instead of creating a new one with a randomized seed. This allows for reusability of an annotator instance for multiple projects by having consistency of Identity. This also allows the annotators to take advantage of the `stronghold` secret management capabilities of the Demia `User` client. 